### PR TITLE
(Missing) Adds GetVirtualAddress method for BigIP

### DIFF
--- a/ltm.go
+++ b/ltm.go
@@ -2273,6 +2273,16 @@ func (b *BigIP) VirtualAddresses() (*VirtualAddresses, error) {
 	return &va, nil
 }
 
+// GetVirtualAddress retrieves a VirtualAddress by name. Returns nil if the VirtualAddress does not exist
+func (b *BigIP) GetVirtualAddress(vaddr string) (*VirtualAddress, error) {
+	var virtualAddress VirtualAddress
+	err, _ := b.getForEntity(&virtualAddress, uriLtm, uriVirtualAddress, vaddr)
+	if err != nil {
+		return nil, err
+	}
+	return &virtualAddress, nil
+}
+
 func (b *BigIP) CreateVirtualAddress(vaddr string, config *VirtualAddress) error {
 	config.Name = vaddr
 	return b.post(config, uriLtm, uriVirtualAddress)


### PR DESCRIPTION
This adds a method to be able to retrieve a particular Virtual Address as this method is missing.

I confirmed all API references via docs  (reference: mgmt/tm/ltm/virtualAddress)
The API accepts ~[resource id]  just as virtualServer does