### PR TITLE
Add tunnels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.iml
 *.back
+*.swp

--- a/app.go
+++ b/app.go
@@ -130,7 +130,7 @@ func (b *BigIP) CreateAppsvc01(p *Appsvc01) error {
 	log.Printf("++++++ Here is what terraform is sending to bigip ................ : %+v ", p)
 	err := b.post(p, uriMgmt, uriSha, uriAppsvcs, uriDecl)
 	if err != nil {
-		log.Println(" API call not successfull  %v ", err)
+		log.Println(" API call not successfull  ", err)
 	}
 	return nil
 }
@@ -138,7 +138,7 @@ func (b *BigIP) CreateAppsvc02(p *Appsvc02) error {
 	log.Printf("++++++ Here is what terraform is sending to bigip ................ : %+v ", p)
 	err := b.post(p, uriMgmt, uriSha, uriAppsvcs, uriDecl)
 	if err != nil {
-		log.Println(" API call not successfull  %v ", err)
+		log.Println(" API call not successfull  ", err)
 	}
 	return nil
 }
@@ -152,9 +152,9 @@ func (b *BigIP) DeleteAppsvc02() error {
 func (b *BigIP) ModifyAppsvc01(p *Appsvc01) error {
 	log.Printf("++++++ Here is what terraform is sending to bigip ................ : %+v ", p)
 	err := b.patch(p, uriMgmt, uriSha, uriAppsvcs, uriDecl)
-	log.Printf("value of p in modify +++++++++++++++", p)
+	log.Println("value of p in modify +++++++++++++++", p)
 	if err != nil {
-		log.Println(" API call not successfull  %v ", err)
+		log.Println(" API call not successfull  ", err)
 	}
 	return nil
 }
@@ -162,7 +162,7 @@ func (b *BigIP) ModifyAppsvc02(p *Appsvc02) error {
 	log.Printf("++++++ Here is what terraform is sending to bigip ................ : %+v ", p)
 	err := b.patch(p, uriMgmt, uriSha, uriAppsvcs, uriDecl)
 	if err != nil {
-		log.Println(" API call not successfull  %v ", err)
+		log.Println(" API call not successfull  ", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Built and tested with the following go version:
```bash
$ go version
go version go1.12.3 darwin/amd64
```

1. Had to change `app.go`'s `Printlln()` function calls due to the following errors when running go test:
```bash
$ go test -v
# github.com/f5devcentral/go-bigip
./app.go:133:3: Println call has possible formatting directive %v
./app.go:141:3: Println call has possible formatting directive %v
./app.go:155:12: Printf call has arguments but no formatting directives
./app.go:157:3: Println call has possible formatting directive %v
./app.go:165:3: Println call has possible formatting directive %v
FAIL	github.com/f5devcentral/go-bigip [build failed]
```

Adding support for creating, updating, deleting, and showing Tunnels.