### PR TITLE
Change F5 TEEM digital asset ID to be distinct per host instance.

### DIFF
--- a/f5teem/f5teem_test.go
+++ b/f5teem/f5teem_test.go
@@ -58,3 +58,17 @@ func TestTeemNotAuthorized(t *testing.T) {
 		t.Errorf("Error:%v", err)
 	}
 }
+
+func TestUniqueUUID(t *testing.T) {
+	expected := "a837ce9d-d34c-e5c1-9fe0-581e2b46c029"
+	oldOS := osHostname
+	defer func() { osHostname = oldOS }()
+
+	osHostname = func() (hostname string, err error) {
+		return "foobar.local.lab", nil
+	}
+	result := uniqueUUID()
+	if result != expected {
+		t.Errorf("Expected UUID to be: %s, got %s", expected, result)
+	}
+}

--- a/f5teem/go.mod
+++ b/f5teem/go.mod
@@ -2,4 +2,7 @@ module github.com/f5devcentral/go-bigip/f5teem
 
 go 1.13
 
-require github.com/google/uuid v1.1.1
+require (
+	github.com/google/uuid v1.1.1
+	github.com/satori/go.uuid v1.2.0 // indirect
+)

--- a/f5teem/go.sum
+++ b/f5teem/go.sum
@@ -1,2 +1,4 @@
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
+github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=


### PR DESCRIPTION
This PR addresses the issue where DAI in F5 TEEM were always random even when run from the same host instance, for consistency in data tracking this has been changed to be more distinct per host basis.