### PR TITLE
update AS3 task errors

### DIFF
--- a/as3bigip.go
+++ b/as3bigip.go
@@ -97,7 +97,8 @@ func (b *BigIP) PostAs3Bigip(as3NewJson string, tenantFilter string) (error, str
 					log.Printf("[DEBUG]Sucessfully Created Application with ID  = %v", respID)
 					break // break here
 				} else if success_count == 0 {
-					return fmt.Errorf("Tenant Creation failed"), ""
+					j, _ := json.MarshalIndent(fastTask["results"].([]interface{}), "", "\t")
+					return fmt.Errorf("Tenant Creation failed. Response: %+v", string(j)), ""
 				} else {
 					finallist := strings.Join(successfulTenants[:], ",")
 					j, _ := json.MarshalIndent(fastTask["results"].([]interface{}), "", "\t")
@@ -109,7 +110,8 @@ func (b *BigIP) PostAs3Bigip(as3NewJson string, tenantFilter string) (error, str
 				break // break here
 			}
 			if respCode >= 400 {
-				return fmt.Errorf("Tenant Creation failed"), ""
+				j, _ := json.MarshalIndent(fastTask["results"].([]interface{}), "", "\t")
+				return fmt.Errorf("Tenant Creation failed. Response: %+v", string(j)), ""
 			}
 		}
 		if respCode == 503 {


### PR DESCRIPTION
This PR updates the `Tenant Creation failed` failed errors with details about the error. The goal is to make the error actionable by a user since it is what gets surfaced when the [AS3 BigIP Terraform Resource](https://registry.terraform.io/providers/F5Networks/bigip/latest/docs/resources/bigip_as3) fails. Previously there was not enough detail returned to fix the problem in the POSTed AS3 JSON.

Unfortunately, tests appear to be failing since #63.