### PR TITLE
Add support for ILX Workspace management

### DIFF
--- a/cmd/ilx_example/example.go
+++ b/cmd/ilx_example/example.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/f5devcentral/go-bigip"
+)
+
+func main() {
+	// Connect to the BIG-IP system.
+	config := bigip.Config{
+		Address:           os.Getenv("BIG_IP_HOST"),
+		Username:          os.Getenv("BIG_IP_USER"),
+		Password:          os.Getenv("BIG_IP_PASSWORD"),
+		CertVerifyDisable: true,
+	}
+
+	f5 := bigip.NewSession(&config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	const wrkspcName = "ExampleWorkspce"
+	err := f5.CreateWorkspace(ctx, wrkspcName)
+	if err != nil {
+		panic(err)
+	}
+	result, err := f5.GetWorkspace(ctx, wrkspcName)
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("Workspace: %v", result)
+	opts := bigip.ExtensionConfig{
+		WorkspaceName: wrkspcName,
+		Name:          "exampleExt",
+		Partition:     "Common",
+	}
+	err = f5.CreateExtension(ctx, opts)
+	if err != nil {
+		panic(err)
+	}
+
+	err = f5.WriteExtensionFile(ctx, opts, "{}", bigip.PackageJSON)
+	if err != nil {
+		panic(err)
+	}
+
+	err = f5.WriteExtensionFile(ctx, opts, "const a = 12;", bigip.IndexJS)
+	if err != nil {
+		panic(err)
+	}
+
+	content, err := f5.ReadExtensionFile(ctx, opts, bigip.IndexJS)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Content: %+v\n", content)
+}

--- a/cmd/ilx_example/ilx/index.js
+++ b/cmd/ilx_example/ilx/index.js
@@ -1,0 +1,26 @@
+var f5 = require("f5-nodejs");
+
+var ilx = new f5.ILXServer();
+
+ilx.addMethod("getCredentials", function (req, res) {
+  const [user] = req.params();
+  const arc = new CyberArc();
+  const credentials = arc.getCredentials(user);
+  res.reply(credentials);
+});
+
+ilx.listen();
+
+/**
+ * @class CyberArc
+ */
+class CyberArc {
+  /**
+   * @method getCredentials
+   * @param {string} user
+   * @returns {Array} [username, password]
+   */
+  getCredentials(username) {
+    return ["admin", "password"];
+  }
+}

--- a/cmd/ilx_example/ilx/package-lock.json
+++ b/cmd/ilx_example/ilx/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "ilx",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ilx",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "f5-nodejs": "^1.0.0",
+        "hexy": "^0.3.5"
+      }
+    },
+    "node_modules/f5-nodejs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/f5-nodejs/-/f5-nodejs-1.0.0.tgz",
+      "integrity": "sha512-NUTwNOKVMqyk65ba4xkabJx77FvEZRJt3gpQjtNOfvEFxKKAHFAhfcgCY8xiP8fL3Iua4so1EJKsMxhVJk5OUg=="
+    },
+    "node_modules/hexy": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.3.5.tgz",
+      "integrity": "sha512-UCP7TIZPXz5kxYJnNOym+9xaenxCLor/JyhKieo8y8/bJWunGh9xbhy3YrgYJUQ87WwfXGm05X330DszOfINZw==",
+      "license": "MIT",
+      "bin": {
+        "hexy": "bin/hexy_cmd.js"
+      },
+      "engines": {
+        "node": ">=10.4"
+      }
+    }
+  }
+}

--- a/cmd/ilx_example/ilx/package.json
+++ b/cmd/ilx_example/ilx/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ilx",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "npm run dev"
+  },
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "f5-nodejs": "^1.0.0",
+    "hexy": "^0.3.5"
+  }
+}

--- a/device.go
+++ b/device.go
@@ -185,19 +185,21 @@ func (p *Devicegroup) UnmarshalJSON(b []byte) error {
 // https://10.192.74.80/mgmt/cm/device/licensing/pool/purchased-pool/licenses
 // The above command will spit out license uuid and which should be mapped uriUuid
 const (
-	uriMgmt          = "mgmt"
-	uriCm            = "cm"
-	uriDiv           = "device"
-	uriDevices       = "devices"
-	uriDG            = "device-group"
-	uriLins          = "licensing"
-	uriPoo           = "pool"
-	uriPur           = "purchased-pool"
-	uriLicn          = "licenses"
-	uriMemb          = "members"
-	uriUtility       = "utility"
-	uriOfferings     = "offerings"
-	uriF5BIGMSPBT10G = "f37c66e0-a80d-43e8-924b-3bbe9fe96bbe"
+	uriMgmt               = "mgmt"
+	uriCm                 = "cm"
+	uriDiv                = "device"
+	uriDevices            = "devices"
+	uriDG                 = "device-group"
+	uriLins               = "licensing"
+	uriPoo                = "pool"
+	uriPur                = "purchased-pool"
+	uriLicn               = "licenses"
+	uriMemb               = "members"
+	uriUtility            = "utility"
+	uriOfferings          = "offerings"
+	uriF5BIGMSPBT10G      = "f37c66e0-a80d-43e8-924b-3bbe9fe96bbe"
+	uriWorkspace          = "workspace"
+	WORKSPACE_UPLOAD_PATH = "/var/ilx/workspaces"
 )
 
 func (p *LIC) MarshalJSON() ([]byte, error) {

--- a/ilx.go
+++ b/ilx.go
@@ -1,0 +1,110 @@
+package bigip
+
+import (
+	"context"
+	"fmt"
+)
+
+type ILXWorkspace struct {
+	Name            string      `json:"name,omitempty"`
+	FullPath        string      `json:"fullPath,omitempty"`
+	SelfLink        string      `json:"selfLink,omitempty"`
+	NodeVersion     string      `json:"nodeVersion,omitempty"`
+	StagedDirectory string      `json:"stagedDirectory,omitempty"`
+	Version         string      `json:"version,omitempty"`
+	Extensions      []Extension `json:"extensions,omitempty"`
+	Rules           []ILXFile   `json:"rules,omitempty"`
+	Generation      int         `json:"generation,omitempty"`
+}
+
+type ILXFile struct {
+	Name    string `json:"name,omitempty"`
+	Content string `json:"content,omitempty"`
+}
+
+type Extension struct {
+	Name  string    `json:"name,omitempty"`
+	Files []ILXFile `json:"files,omitempty"`
+}
+
+func (b *BigIP) GetWorkspace(ctx context.Context, path string) (*ILXWorkspace, error) {
+	spc := &ILXWorkspace{}
+	err, exists := b.getForEntity(spc, uriMgmt, uriTm, uriIlx, uriWorkspace, path)
+	if !exists {
+		return nil, fmt.Errorf("workspace does not exist: %w", err)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("error getting ILX Workspace: %w", err)
+	}
+
+	return spc, nil
+}
+
+func (b *BigIP) CreateWorkspace(ctx context.Context, path string) error {
+	err := b.post(ILXWorkspace{Name: path}, uriMgmt, uriTm, uriIlx, uriWorkspace, "")
+	if err != nil {
+		return fmt.Errorf("error creating ILX Workspace: %w", err)
+	}
+
+	return nil
+}
+
+func (b *BigIP) DeleteWorkspace(ctx context.Context, name string) error {
+	err := b.delete(uriMgmt, uriTm, uriIlx, uriWorkspace, name)
+	if err != nil {
+		return fmt.Errorf("error deleting ILX Workspace: %w", err)
+	}
+	return nil
+}
+
+type ExtensionConfig struct {
+	Name          string `json:"name,omitempty"`
+	Partition     string `json:"partition,omitempty"`
+	WorkspaceName string `json:"workspaceName,omitempty"`
+}
+
+func (b *BigIP) CreateExtension(ctx context.Context, opts ExtensionConfig) error {
+	err := b.post(ILXWorkspace{Name: opts.WorkspaceName}, uriMgmt, uriTm, uriIlx, uriWorkspace+"?options=extension,"+opts.Name)
+	if err != nil {
+		return fmt.Errorf("error creating ILX Extension: %w", err)
+	}
+	return nil
+}
+
+type ExtensionFile string
+
+func (e ExtensionFile) Validate() error {
+	if e != PackageJSON && e != IndexJS {
+		return fmt.Errorf("invalid extension file")
+	}
+	return nil
+}
+
+const (
+	PackageJSON ExtensionFile = "package.json"
+	IndexJS     ExtensionFile = "index.js"
+)
+
+func (b *BigIP) WriteExtensionFile(ctx context.Context, opts ExtensionConfig, content string, filename ExtensionFile) error {
+	if err := filename.Validate(); err != nil {
+		return err
+	}
+	destination := fmt.Sprintf("%s/%s/%s/extensions/%s/%s", WORKSPACE_UPLOAD_PATH, opts.Partition, opts.WorkspaceName, opts.Name, filename)
+	err := b.WriteFile(content, destination)
+	if err != nil {
+		return fmt.Errorf("error uploading packagejson: %w", err)
+	}
+	return nil
+}
+
+func (b *BigIP) ReadExtensionFile(ctx context.Context, opts ExtensionConfig, filename ExtensionFile) (*ILXFile, error) {
+	if err := filename.Validate(); err != nil {
+		return nil, err
+	}
+	destination := fmt.Sprintf("%s/%s/%s/extensions/%s/%s", WORKSPACE_UPLOAD_PATH, opts.Partition, opts.WorkspaceName, opts.Name, filename)
+	files, err := b.ReadFile(destination)
+	if err != nil {
+		return nil, err
+	}
+	return files, nil
+}


### PR DESCRIPTION
# Add support for ILX Workspace management

This pull request implements the feature request outlined in issue #105, adding support for ILX Workspace Creation, Deletion, Modification, and File Upload to the F5 BIG-IP Go SDK.

## Changes Implemented

1. Added `ILXWorkspace`, `ILXFile`, and `Extension` structs in a new `ilx.go` file to represent ILX workspace components.
2. Implemented the following methods in the `BigIP` struct:
   - `GetWorkspace(ctx context.Context, path string) (*ILXWorkspace, error)`
   - `CreateWorkspace(ctx context.Context, path string) error`
   - `DeleteWorkspace(ctx context.Context, name string) error`
   - `CreateExtension(ctx context.Context, opts ExtensionConfig) error`
   - `WriteExtensionFile(ctx context.Context, opts ExtensionConfig, content string, filename ExtensionFile) error`
   - `ReadExtensionFile(ctx context.Context, opts ExtensionConfig, filename ExtensionFile) (*ILXFile, error)`
3. Added `WriteFile` and `ReadFile` methods to `sys.go` 
4. Created a new example in `cmd/ilx_workspace/example.go`
## Testing

- Manual testing has been performed with the new example in `cmd/ilx_workspace/example.go`.

## Additional Notes

- The new example location (`cmd/ilx_workspace/example.go`) differs from the previous convention. This was done to address issues with outdated and non-functional examples in the previous location.
- The implementation uses the `run` command with `echo` and `cat` for file operations, which may need to be reviewed for security and efficiency.

## Related Issue

Closes #105

Please review and let me know if any further changes or information are needed.