### PR TITLE
Add support for Webtop management

### DIFF
--- a/apm.go
+++ b/apm.go
@@ -1,0 +1,117 @@
+package bigip
+
+import (
+	"context"
+	"encoding/json"
+)
+
+type (
+	WebtopType        string
+	CustomizationType string
+	InitialState      string
+	LinkType          string
+)
+
+const (
+	WebtopTypePortal  WebtopType = "portal-access"
+	WebtopTypeFull               = "full"
+	WebtopTypeNetwork            = "network-access"
+)
+
+const (
+	CustomizationTypeModern   CustomizationType = "Modern"
+	CustomizationTypeStandard                   = "Standard"
+)
+
+const (
+	InitialStateCollapsed InitialState = "Collapsed"
+	InitialStateExpanded               = "Expanded"
+)
+
+const (
+	LinkTypeUri LinkType = "uri"
+)
+
+// Some endpoints have a "booledString" a boolean value that is represented as a string in the json payload
+type BooledString bool
+
+func (b BooledString) MarshalJSON() ([]byte, error) {
+	str := "false"
+	if b {
+		str = "true"
+	}
+	return json.Marshal(str)
+}
+
+func (b BooledString) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+	b = str == "true"
+	return nil
+}
+
+// Values in WebtopConfig are updateable
+type WebtopConfig struct {
+	Description        string            `json:"description,omitempty"`
+	LinkType           LinkType          `json:"linkType,omitempty"`
+	CustomizationGroup string            `json:"customizationGroup"`
+	Type               WebtopType        `json:"webtopType,omitempty"`
+	CustomizationType  CustomizationType `json:"customizationType,omitempty"`
+	LocationSpecific   BooledString      `json:"locationSpecific"`
+	MinimizeToTray     BooledString      `json:"minimizeToTray"`
+	ShowSearch         BooledString      `json:"showSearch"`
+	WarningOnClose     BooledString      `json:"warningOnClose"`
+	UrlEntryField      BooledString      `json:"urlEntryField"`
+	ResourceSearch     BooledString      `json:"resourceSearch"`
+	InitialState       InitialState      `json:"initialState,omitempty"`
+}
+
+// Only the values within WebtopConfig can be updated. Any changes made to non-config values will be ignored when using UpdateWebtop.
+type Webtop struct {
+	Name        string `json:"name,omitempty"`
+	Partition   string `json:"partition,omitempty"`
+	TMPartition string `json:"tmPartition,omitempty"`
+	WebtopConfig
+}
+
+type WebtopRead struct {
+	Webtop
+	FullPath                    string `json:"fullPath,omitempty"`
+	Generation                  int    `json:"generation,omitempty"`
+	SelfLink                    string `json:"selfLink,omitempty"`
+	CustomizationGroupReference struct {
+		Link string `json:"link,omitempty"`
+	} `json:"customizationGroupReference,omitempty"`
+}
+
+func (b *BigIP) CreateWebtop(ctx context.Context, webtop Webtop) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return b.post(webtop, uriMgmt, uriTm, uriApm, uriResource, uriWebtop)
+}
+
+func (b *BigIP) DeleteWebtop(ctx context.Context, name string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return b.delete(uriMgmt, uriTm, uriApm, uriResource, uriWebtop, name)
+}
+
+func (b *BigIP) GetWebtop(ctx context.Context, name string) (*WebtopRead, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	var webtop WebtopRead
+	err, _ := b.getForEntity(&webtop, uriMgmt, uriTm, uriApm, uriResource, uriWebtop, name)
+	return &webtop, err
+}
+
+func (b *BigIP) ModifyWebtop(ctx context.Context, name string, webtop WebtopConfig) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return b.patch(webtop, uriMgmt, uriTm, uriApm, uriResource, uriWebtop, name)
+}

--- a/cmd/webtop_example/example.go
+++ b/cmd/webtop_example/example.go
@@ -25,7 +25,7 @@ func main() {
 	defer cancel()
 
 	conf := bigip.WebtopConfig{
-		Description:        "Call me",
+		Description:        "A webtop example",
 		Type:               bigip.WebtopTypePortal,
 		LinkType:           bigip.LinkTypeUri,
 		CustomizationType:  bigip.CustomizationTypeModern,

--- a/cmd/webtop_example/example.go
+++ b/cmd/webtop_example/example.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/f5devcentral/go-bigip"
+)
+
+func main() {
+	// Connect to the BIG-IP system.
+	config := bigip.Config{
+		Address:           os.Getenv("BIG_IP_HOST"),
+		Username:          os.Getenv("BIG_IP_USER"),
+		Password:          os.Getenv("BIG_IP_PASSWORD"),
+		CertVerifyDisable: true,
+	}
+
+	f5 := bigip.NewSession(&config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	conf := bigip.WebtopConfig{
+		Description:        "Call me",
+		Type:               bigip.WebtopTypePortal,
+		LinkType:           bigip.LinkTypeUri,
+		CustomizationType:  bigip.CustomizationTypeModern,
+		CustomizationGroup: "/Common/webtop_customization",
+		LocationSpecific:   false,
+		MinimizeToTray:     true,
+		ShowSearch:         true,
+		WarningOnClose:     false,
+		UrlEntryField:      true,
+		ResourceSearch:     false,
+		InitialState:       bigip.InitialStateCollapsed,
+	}
+	webtop := bigip.Webtop{
+		Name:         "ExampleName",
+		Partition:    "Common",
+		TMPartition:  "Common",
+		WebtopConfig: conf,
+	}
+
+	err := f5.CreateWebtop(ctx, webtop)
+	if err != nil {
+		log.Fatalf("Failed to create webtop: %v", err)
+	}
+	webtopGet, err := f5.GetWebtop(ctx, webtop.Name)
+	if err != nil {
+		log.Fatalf("Failed to get webtop: %v", err)
+	}
+	fmt.Printf("%+v\n", webtopGet)
+	err = f5.DeleteWebtop(ctx, webtop.Name)
+	if err != nil {
+		log.Fatalf("Failed to delete webtop: %v", err)
+	}
+	log.Println("Webtop created")
+}

--- a/device.go
+++ b/device.go
@@ -198,6 +198,9 @@ const (
 	uriUtility       = "utility"
 	uriOfferings     = "offerings"
 	uriF5BIGMSPBT10G = "f37c66e0-a80d-43e8-924b-3bbe9fe96bbe"
+
+	uriResource = "resource"
+	uriWebtop   = "webtop"
 )
 
 func (p *LIC) MarshalJSON() ([]byte, error) {
@@ -330,6 +333,7 @@ func (b *BigIP) CreateDevicegroup(p *Devicegroup) error {
 func (b *BigIP) UpdateDevicegroup(name string, p *Devicegroup) error {
 	return b.put(p, uriCm, uriDG, name)
 }
+
 func (b *BigIP) ModifyDevicegroup(config *Devicegroup) error {
 	return b.put(config, uriCm, uriDG)
 }


### PR DESCRIPTION
# Add support for Webtop management

This pull request implements the feature request outlined in issue #107, adding support for Webtop Creation, Deletion, Modification, and Retrieval to the F5 BIG-IP Go SDK.

## Changes Implemented

1. Added new types and constants in `apm.go`:
   - `WebtopType`, `CustomizationType`, `InitialState`, and `LinkType`
   - `BooledString` for handling boolean values represented as strings in JSON payloads
2. Implemented `Webtop`, `WebtopConfig`, and `WebtopRead` structs in `apm.go`.
3. Added the following methods to the `BigIP` struct in `apm.go`:
   - `CreateWebtop(ctx context.Context, webtop Webtop) error`
   - `DeleteWebtop(ctx context.Context, name string) error`
   - `GetWebtop(ctx context.Context, name string) (*WebtopRead, error)`
   - `ModifyWebtop(ctx context.Context, name string, webtop WebtopConfig) error`
4. Created a new example in `cmd/webtop/example.go` to demonstrate the usage of the new Webtop functionality.

## Implementation Details

- The `Webtop` struct represents the configuration for creating or updating a Webtop.
- The `WebtopRead` struct includes additional fields returned when retrieving a Webtop.
- The `BooledString` type handles the conversion between boolean values and their string representations in the API.

## Testing
- Manual testing has been performed with the new example in `cmd/webtop/example.go`.

## Additional Notes
- The `ModifyWebtop` method only allows updating the `WebtopConfig` fields, as per the API specifications.

## Related Issue
Closes #107

Please review and let me know if any further changes or information are needed.