### PR TITLE
feat: Add Address List and Traffic Matching Criteria functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,22 @@
 [//]: # (WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.)
 [//]: # (See the License for the specific language governing permissions and limitations under the License.)
 
+-----
+
+This is a fork of <https://github.com/f5devcentral/go-bigip>, pulled from <https://github.com/retryW/go-bigip/tree/feat_tmc_address_lists>
+
+Currently this adds the following features not yet provided by the vendor:
+
+- Traffic Matching Criteria
+- Address Lists
+- Universal Persistence Profiles
+
+This project is a prerequisite for the terraform-provider-bigip fork.
+
+-----
+
 ## go-bigip
+
 [![GoDoc](https://godoc.org/github.com/f5devcentral/go-bigip?status.svg)](https://godoc.org/github.com/f5devcentral/go-bigip) [![Travis-CI](https://travis-ci.org/f5devcentral/go-bigip.svg?branch=master)](https://travis-ci.org/f5devcentral/go-bigip)
 [![Go Report Card](https://goreportcard.com/badge/github.com/f5devcentral/go-bigip)](https://goreportcard.com/report/github.com/f5devcentral/go-bigip)
 [![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/f5devcentral/go-bigip/master/LICENSE)

--- a/cmd/addresslist_example/example.go
+++ b/cmd/addresslist_example/example.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/f5devcentral/go-bigip"
+)
+
+func main() {
+	// Connect to the BIG-IP system.
+	config := bigip.Config{
+		Address:  os.Getenv("BIG_IP_HOST"),
+		Username: os.Getenv("BIG_IP_USER"),
+		Password: os.Getenv("BIG_IP_PASSWORD"),
+	}
+
+	f5 := bigip.NewSession(&config)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Create an Address List
+	addressList := &bigip.AddressList{
+		Name: "addresslist-example",
+		Partition: "Common",
+		Addresses: []bigip.AddressListAddress{
+			{ Name: "1.2.3.4" },
+		},
+	}
+
+	err := f5.AddAddressList(ctx, addressList)
+
+	if err != nil {
+    log.Fatalf("Failed to create address list: %v", err)
+	}
+
+	// Get the address list
+	addressListGet, err := f5.GetAddressList(ctx, addressList.Name)
+	if err != nil {
+		log.Fatalf("Failed to get address list: %v", err)
+	}
+	fmt.Printf("%+v\n", addressListGet)
+
+	// Create a traffic matching criteria
+	trafficMatchingCriteria := &bigip.TrafficMatchingCriteria{
+		Name: "tmc-example",
+		Partition: "Common",
+		DestinationAddressInline: "192.168.1.150",
+		DestinationPortInline: "443",
+		SourceAddressList: fmt.Sprintf("/%s/%s", addressList.Partition, addressList.Name),
+		SourcePortInline: 0,
+	}
+
+	err = f5.AddTrafficMatchingCriteria(ctx, trafficMatchingCriteria)
+
+	if err != nil {
+		log.Fatalf("Failed to create traffic matching criteria: %v", err)
+	}
+
+	// Get the traffic matching criteria
+	trafficMatchingCriteriaGet, err := f5.GetTrafficMatchingCriteria(ctx, trafficMatchingCriteria.Name)
+	if err != nil {
+		log.Fatalf("Failed to get traffic matching criteria: %v", err)
+	}
+	fmt.Printf("%+v\n", trafficMatchingCriteriaGet)
+
+	// Create a virtual server using the address list and traffic matching criteria
+	virtualServer := &bigip.VirtualServer{
+		Name: "virtualserver-example",
+		Partition: "Common",
+		Destination: ":0",
+		Source: "0.0.0.0/0",
+		IPProtocol: "tcp",
+		Mask: "255.255.255.255",
+		TrafficMatchingCriteria: fmt.Sprintf("/%s/%s", trafficMatchingCriteria.Partition, trafficMatchingCriteria.Name),
+	}
+
+	err = f5.AddVirtualServer(virtualServer)
+	if err != nil {
+		log.Fatalf("Failed to create virtual server: %v", err)
+	}
+
+	// Get the virtual server
+	virtualServerGet, err := f5.GetVirtualServer(virtualServer.Name)
+	if err != nil {
+		log.Fatalf("Failed to get virtual server: %v", err)
+	}
+	fmt.Printf("%+v\n", virtualServerGet)
+
+	fmt.Println("Virtual server with address list created")
+
+	err = f5.DeleteVirtualServer(virtualServer.Name)
+	if err != nil {
+		log.Fatalf("Failed to delete virtual server: %v", err)
+	}
+
+	err = f5.DeleteTrafficMatchingCriteria(ctx, trafficMatchingCriteria.Name)
+	if err != nil {
+		log.Fatalf("Failed to delete traffic matching criteria: %v", err)
+	}
+
+	err = f5.DeleteAddressList(ctx, addressList.Name)
+	if err != nil {
+		log.Fatalf("Failed to delete address list: %v", err)
+	}
+
+	fmt.Println("virutal server, traffic matching criteria, and address list deleted.")
+}
+

--- a/ltm.go
+++ b/ltm.go
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and limitations 
 package bigip
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -2167,65 +2168,89 @@ type ResponseAdaptProfile struct {
 	Timeout           int    `json:"timeout,omitempty"`
 }
 
+// TrafficMatchingCriteria contains a list of TrafficMatchingCriteria objects.
+type TrafficMatchingCriterias struct {
+	TrafficMatchingCriterias []TrafficMatchingCriteria `json:"items"`
+}
+
+// TrafficMatchingCriteria contains information about each Traffic-Matching-Criteria.
+type TrafficMatchingCriteria struct {
+	Name                     string   `json:"name,omitempty"`
+	Partition                string   `json:"partition,omitempty"`
+	FullPath                 string   `json:"fullPath,omitempty"`
+	Generation               int      `json:"generation,omitempty"`
+	Description              string   `json:"description,omitempty"`
+	Protocol                 string   `json:"protocol,omitempty"`
+	RouteDomain              string   `json:"routeDomain,omitempty"`
+	DestinationAddressList   string   `json:"destinationAddressList,omitempty"`
+	DestinationAddressInline string   `json:"destinationAddressInline,omitempty"`
+	DestinationPortList      string   `json:"destinationPortList,omitempty"`
+	DestinationPortInline    string   `json:"destinationPortInline,omitempty"`
+	SourceAddressList        string   `json:"sourceAddressList,omitempty"`
+	SourceAddressInline      string   `json:"sourceAddressInline,omitempty"`
+	SourcePortInline         int      `json:"sourcePortInline,omitempty"`
+}
+
 const (
-	uriLtm             = "ltm"
-	uriNode            = "node"
-	uriPool            = "pool"
-	uriPoolMember      = "members"
-	uriProfile         = "profile"
-	uriCipher          = "cipher"
-	uriServerSSL       = "server-ssl"
-	uriClientSSL       = "client-ssl"
-	uriVirtual         = "virtual"
-	uriVirtualAddress  = "virtual-address"
-	uriSnatPool        = "snatpool"
-	uriMonitor         = "monitor"
-	uriIRule           = "rule"
-	uriDatagroup       = "data-group"
-	uriInternal        = "internal"
-	uriExternal        = "external"
-	uriPolicy          = "policy"
-	uriOneconnect      = "one-connect"
-	uriPersistence     = "persistence"
-	ENABLED            = "enable"
-	DISABLED           = "disable"
-	CONTEXT_SERVER     = "serverside"
-	CONTEXT_CLIENT     = "clientside"
-	CONTEXT_ALL        = "all"
-	uriRewrite         = "rewrite"
-	uriRewriteRules    = "uri-rules"
-	uriTcp             = "tcp"
-	uriUDP             = "udp"
-	uriFtp             = "ftp"
-	uriFasthttp        = "fasthttp"
-	uriFastl4          = "fastl4"
-	uriHttpcompress    = "http-compression"
-	uriHttp2           = "http2"
-	uriSnat            = "snat"
-	uriSnatpool        = "snatpool"
-	uriCookie          = "cookie"
-	uriDestAddr        = "dest-addr"
-	uriHash            = "hash"
-	uriHost            = "host"
-	uriMSRDP           = "msrdp"
-	uriSIP             = "sip"
-	uriSourceAddr      = "source-addr"
-	uriSSL             = "ssl"
-	uriUniversal       = "universal"
-	uriCreateDraft     = "?options=create-draft"
-	uriRule            = "rule"
-	uriWebAcceleration = "web-acceleration"
-	uriHttp            = "http"
-	uriRequestLog      = "request-log"
-	uriSecurity        = "security"
-	uriBotDefense      = "bot-defense"
-	uriSaas            = "saas"
-	uriSaasBotDefense  = "bd"
-	uriRequestAdapt    = "request-adapt"
-	uriResponseAdapt   = "response-adapt"
-	uriWebsocket       = "websocket"
-	uriHTML            = "html"
-	uriAnalytics       = "analytics"
+	uriLtm                     = "ltm"
+	uriNode                    = "node"
+	uriPool                    = "pool"
+	uriPoolMember              = "members"
+	uriProfile                 = "profile"
+	uriCipher                  = "cipher"
+	uriServerSSL               = "server-ssl"
+	uriClientSSL               = "client-ssl"
+	uriVirtual                 = "virtual"
+	uriVirtualAddress          = "virtual-address"
+	uriSnatPool                = "snatpool"
+	uriMonitor                 = "monitor"
+	uriIRule                   = "rule"
+	uriDatagroup               = "data-group"
+	uriInternal                = "internal"
+	uriExternal                = "external"
+	uriPolicy                  = "policy"
+	uriOneconnect              = "one-connect"
+	uriPersistence             = "persistence"
+	uriTrafficMatchingCriteria = "traffic-matching-criteria"
+	ENABLED                    = "enable"
+	DISABLED                   = "disable"
+	CONTEXT_SERVER             = "serverside"
+	CONTEXT_CLIENT             = "clientside"
+	CONTEXT_ALL                = "all"
+	uriRewrite                 = "rewrite"
+	uriRewriteRules            = "uri-rules"
+	uriTcp                     = "tcp"
+	uriUDP                     = "udp"
+	uriFtp                     = "ftp"
+	uriFasthttp                = "fasthttp"
+	uriFastl4                  = "fastl4"
+	uriHttpcompress            = "http-compression"
+	uriHttp2                   = "http2"
+	uriSnat                    = "snat"
+	uriSnatpool                = "snatpool"
+	uriCookie                  = "cookie"
+	uriDestAddr                = "dest-addr"
+	uriHash                    = "hash"
+	uriHost                    = "host"
+	uriMSRDP                   = "msrdp"
+	uriSIP                     = "sip"
+	uriSourceAddr              = "source-addr"
+	uriSSL                     = "ssl"
+	uriUniversal               = "universal"
+	uriCreateDraft             = "?options=create-draft"
+	uriRule                    = "rule"
+	uriWebAcceleration         = "web-acceleration"
+	uriHttp                    = "http"
+	uriRequestLog              = "request-log"
+	uriSecurity                = "security"
+	uriBotDefense              = "bot-defense"
+	uriSaas                    = "saas"
+	uriSaasBotDefense          = "bd"
+	uriRequestAdapt            = "request-adapt"
+	uriResponseAdapt           = "response-adapt"
+	uriWebsocket               = "websocket"
+	uriHTML                    = "html"
+	uriAnalytics               = "analytics"
 )
 
 var cidr = map[string]string{
@@ -4941,4 +4966,71 @@ func (b *BigIP) DeleteAnalyticsProfile(name string) error {
 // Fields that can be modified are referenced in the AnalyticsProfile struct.
 func (b *BigIP) ModifyAnalyticsProfile(name string, config *AnalyticsProfile) error {
 	return b.patch(config, uriLtm, uriProfile, uriAnalytics, name)
+}
+
+// GetTrafficMatchingCriteria returns all TrafficMatchingCriteria objects on the Big-IP system.
+func (b *BigIP) TrafficMatchingCriterias(ctx context.Context) (*TrafficMatchingCriterias, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	var trafficMatchingCriterias TrafficMatchingCriterias
+	err, ok := b.getForEntity(&trafficMatchingCriterias, uriLtm, uriTrafficMatchingCriteria)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, nil
+	}
+
+	return &trafficMatchingCriterias, nil
+}
+
+// GetTrafficMatchingCriteria returns a single named TrafficMatchingCriteria.
+// Returns nil if the Traffic Matching Criteria does not exist.
+func (b *BigIP) GetTrafficMatchingCriteria(ctx context.Context, name string) (*TrafficMatchingCriteria, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	var trafficMatchingCriteria TrafficMatchingCriteria
+	err, ok := b.getForEntity(&trafficMatchingCriteria, uriLtm, uriTrafficMatchingCriteria, name)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, nil
+	}
+
+	return &trafficMatchingCriteria, nil
+}
+
+// AddTrafficMatchingCritera creates a Traffic Matching Criteria object on the Big-IP system.
+func (b *BigIP) AddTrafficMatchingCriteria(ctx context.Context, config *TrafficMatchingCriteria) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return b.post(config, uriLtm, uriTrafficMatchingCriteria)
+}
+
+// ModifyTrafficMatchingCriteria modifies a Traffic Matching Criteria object on the Big-IP system.
+func (b *BigIP) ModifyTrafficMatchingCriteria(ctx context.Context, name string, config *TrafficMatchingCriteria) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return b.patch(config, uriLtm, uriTrafficMatchingCriteria, name)
+}
+
+// DeleteTrafficMatchingCriteria removes a Traffic Matching Criteria object from the Big-IP system.
+func (b *BigIP) DeleteTrafficMatchingCriteria (ctx context.Context, name string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return b.delete(uriLtm, uriTrafficMatchingCriteria, name)
 }

--- a/ltm_test.go
+++ b/ltm_test.go
@@ -1,0 +1,145 @@
+package bigip
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Utilizes the NetTestSuite from net_test.go
+
+func (s *NetTestSuite) TestTrafficMatchingCriteria() {
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+  "kind": "tm:ltm:traffic-matching-criteria:traffic-matching-criteriacollectionstate",
+	"selfLink": "https://localhost/mgmt/tm/ltm/traffic-matching-criteria?ver=1.2.3.4",
+	"items": [
+	  {
+			"kind": "tm:ltm:traffic-matching-criteria:traffic-matching-criteriastate",
+			"name": "tmc-foo",
+			"partition": "/Common",
+			"fullPatch": "/Common/tmc-foo",
+			"generation": 1,
+			"selfLink": "https://localhost/mgmt/tm/ltm/traffic-matching-criteria/~Common~tmc-foo?ver=1.2.3.4",
+			"destinationAddressInline": "192.168.1.100",
+			"destinationPortInline": "443",
+			"protocol": "tcp",
+			"routeDomain": "any",
+			"sourceAddressInline": "0.0.0.0",
+			"sourceAddressList": "/Common/addresslist-foo",
+			"sourceAddressListReference": {
+			  "link": "https://localhost/mgmt/tm/net/address-list/~Common~addresslist-foo?ver=1.2.3.4"
+			},
+			"sourcePortInline": 0
+		},
+	  {
+			"kind": "tm:ltm:traffic-matching-criteria:traffic-matching-criteriastate",
+			"name": "tmc-bar",
+			"partition": "/Common",
+			"fullPatch": "/Common/tmc-bar",
+			"generation": 1,
+			"selfLink": "https://localhost/mgmt/tm/ltm/traffic-matching-criteria/~Common~tmc-bar?ver=1.2.3.4",
+			"destinationAddressInline": "192.168.1.100",
+			"destinationPortInline": "443",
+			"protocol": "tcp",
+			"routeDomain": "any",
+			"sourceAddressInline": "0.0.0.0",
+			"sourceAddressList": "/Common/addresslist-foo",
+			"sourceAddressListReference": {
+			  "link": "https://localhost/mgmt/tm/net/address-list/~Common~addresslist-foo?ver=1.2.3.4"
+			},
+			"sourcePortInline": 0
+		}]}`))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	trafficMatchingCriterias, err := s.Client.TrafficMatchingCriterias(ctx)
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "GET", "/mgmt/tm/ltm/traffic-matching-criteria", "")
+	assert.Equal(s.T(), 2, len(trafficMatchingCriterias.TrafficMatchingCriterias))
+	assert.Equal(s.T(), "tmc-foo", trafficMatchingCriterias.TrafficMatchingCriterias[0].Name)
+	assert.Equal(s.T(), "tmc-bar", trafficMatchingCriterias.TrafficMatchingCriterias[1].Name)
+}
+
+func (s *NetTestSuite) TestGetTrafficMatchingCriteria() {
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+			"kind": "tm:ltm:traffic-matching-criteria:traffic-matching-criteriastate",
+			"name": "tmc-foo",
+			"partition": "/Common",
+			"fullPatch": "/Common/tmc-foo",
+			"generation": 1,
+			"selfLink": "https://localhost/mgmt/tm/ltm/traffic-matching-criteria/~Common~tmc-foo?ver=1.2.3.4",
+			"destinationAddressInline": "192.168.1.100",
+			"destinationPortInline": "443",
+			"protocol": "tcp",
+			"routeDomain": "any",
+			"sourceAddressInline": "0.0.0.0",
+			"sourceAddressList": "/Common/addresslist-foo",
+			"sourceAddressListReference": {
+			  "link": "https://localhost/mgmt/tm/net/address-list/~Common~addresslist-foo?ver=1.2.3.4"
+			},
+			"sourcePortInline": 0
+		}`))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	trafficMatchingCriteria, err := s.Client.GetTrafficMatchingCriteria(ctx, "tmc-foo")
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "GET", "/mgmt/tm/ltm/traffic-matching-criteria/tmc-foo", "")
+	assert.Equal(s.T(), "tmc-foo", trafficMatchingCriteria.Name)
+	assert.Equal(s.T(), "/Common/addresslist-foo", trafficMatchingCriteria.SourceAddressList)
+}
+
+func (s *NetTestSuite) TestAddTrafficMatchingCriteria() {
+	someTrafficMatchingCriteria := &TrafficMatchingCriteria{
+		Name: "tmc-foo",
+		Partition: "Common",
+		DestinationAddressInline: "192.168.1.100",
+		DestinationPortInline: "443",
+		Protocol: "tcp",
+		SourceAddressInline: "0.0.0.0",
+		SourceAddressList: "/Common/addresslist-foo",
+		SourcePortInline: 0,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := s.Client.AddTrafficMatchingCriteria(ctx, someTrafficMatchingCriteria)
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "POST", "/mgmt/tm/ltm/traffic-matching-criteria", `{"name":"tmc-foo","partition":"Common","destinationAddressInline":"192.168.1.100","destinationPortInline":"443","protocol":"tcp","sourceAddressInline":"0.0.0.0","sourceAddressList":"/Common/addresslist-foo"}`)
+}
+
+func (s *NetTestSuite) TestModifyTrafficMatchingCriteria() {
+	someTrafficMatchingCriteriaMod := &TrafficMatchingCriteria{
+		SourceAddressList: "/Common/addresslist-bar",
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := s.Client.ModifyTrafficMatchingCriteria(ctx, "tmc-foo", someTrafficMatchingCriteriaMod)
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "PATCH", "/mgmt/tm/ltm/traffic-matching-criteria/tmc-foo", `{"sourceAddressList":"/Common/addresslist-bar"}`)
+}
+
+func (s *NetTestSuite) TestDeleteTrafficMatchingCriteria() {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := s.Client.DeleteTrafficMatchingCriteria(ctx, "tmc-foo")
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "DELETE", "/mgmt/tm/ltm/traffic-matching-criteria/tmc-foo", "")
+}
+

--- a/net.go
+++ b/net.go
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and limitations 
 package bigip
 
 import (
+	"context"
 	"regexp"
 	"strings"
 )
@@ -309,6 +310,23 @@ type IPSecProfile struct {
 	TrafficSelector string `json:"trafficSelector,omitempty"`
 }
 
+type AddressLists struct {
+	AddressLists []AddressList `json:"items,omitempty"`
+}
+
+type AddressList struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Partition   string `json:"partition,omitempty"`
+	FullPath    string `json:"fullPath,omitempty"`
+	Generation  int    `json:"generation,omitempty"`
+	Addresses   []AddressListAddress `json:"addresses,omitempty"`
+}
+
+type AddressListAddress struct {
+	Name string `json:"name,omitempty"`
+}
+
 const (
 	uriNet             = "net"
 	uriInterface       = "interface"
@@ -325,6 +343,7 @@ const (
 	uriTrafficselector = "traffic-selector"
 	uriIpsecPolicy     = "ipsec-policy"
 	uriIkePeer         = "ike-peer"
+	uriAddressList     = "address-list"
 )
 
 // formatResourceID takes the resource name to
@@ -823,3 +842,63 @@ func (b *BigIP) GetIPSecProfile(name string) (*IPSecProfile, error) {
 
 	return &ipsec, nil
 }
+
+func (b *BigIP) AddressLists(ctx context.Context) (*AddressLists, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+	var addressLists AddressLists
+	err, ok := b.getForEntity(&addressLists, uriNet, uriAddressList)
+	if err != nil {
+    return nil, err
+	}
+
+	if !ok {
+		return nil, nil
+	}
+
+	return &addressLists, nil
+}
+
+func (b *BigIP) GetAddressList(ctx context.Context, name string) (*AddressList, error) {
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+
+  var addressList AddressList
+	err, ok := b.getForEntity(&addressList, uriNet, uriAddressList, name)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, nil
+	}
+	return &addressList, nil
+}
+
+func (b *BigIP) AddAddressList(ctx context.Context, config *AddressList) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return b.post(config, uriNet, uriAddressList)
+}
+
+func (b *BigIP) ModifyAddressList(ctx context.Context, name string, config *AddressList) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return b.patch(config, uriNet, uriAddressList, name)
+}
+
+func (b *BigIP) DeleteAddressList(ctx context.Context, name string) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
+	return b.delete(uriNet, uriAddressList, name)
+}
+

--- a/net_test.go
+++ b/net_test.go
@@ -1,10 +1,12 @@
 package bigip
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -248,7 +250,11 @@ func (s *NetTestSuite) TestVlans() {
 }
 
 func (s *NetTestSuite) TestCreateVLan() {
-	err := s.Client.CreateVlan("name", 1)
+	someVlan := &Vlan{
+		Name: "name",
+		Tag: 1,
+	}
+	err := s.Client.CreateVlan(someVlan)
 
 	assert.Nil(s.T(), err)
 	assertRestCall(s, "POST", "/mgmt/tm/net/vlan", `{"name":"name", "tag":1, "sflow":{}}`)
@@ -487,7 +493,7 @@ func (s *NetTestSuite) TestGetTunnel() {
 	tunnel, err := s.Client.GetTunnel("http-tunnel")
 
 	assert.Nil(s.T(), err)
-	assertRestCall(s, "GET", "/mgmt/tm/net/tunnels/tunnel/~Common~http-tunnel", "")
+	assertRestCall(s, "GET", "/mgmt/tm/net/tunnels/tunnel/http-tunnel", "")
 	assert.Equal(s.T(), "http-tunnel", tunnel.Name)
 	assert.Equal(s.T(), "/Common/tcp-forward", tunnel.Profile)
 }
@@ -665,3 +671,135 @@ func (s *NetTestSuite) TestModifyVxlan() {
 	assert.Nil(s.T(), err)
 	assertRestCall(s, "PUT", "/mgmt/tm/net/tunnels/vxlan/some-foo-vxlan", `{"port":456}`)
 }
+
+var someAddresses = []AddressListAddress{
+  { Name: "1.2.3.4" },
+  { Name: "4.3.2.1" },
+}
+
+func (s *NetTestSuite) TestAddressLists() {
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+	"kind": "tm:net:address-list:address-listcollectionstate",
+	"selfLink": "https://localhost/mgmt/tm/net/address-list?ver=1.2.3.4",
+	"items": [
+	  {
+			"kind": "tm:net:address-list:address-liststate",
+			"selfLink": "https://localhost/mgmt/tm/net/address-list/~Common~addresslist-foo?ver=1.2.3.4",
+			"name": "addresslist-foo",
+			"partition": "Common",
+			"fullPath": "/Common/addresslist-foo",
+			"generation": 1,
+			"description": "An address list",
+			"addresses": [
+			  {
+					"name": "1.2.3.4"
+				},
+				{
+					"name": "4.3.2.1"
+				}
+			]
+		},
+	  {
+			"kind": "tm:net:address-list:address-liststate",
+			"selfLink": "https://localhost/mgmt/tm/net/address-list/~Common~addresslist-bar?ver=1.2.3.4",
+			"name": "addresslist-bar",
+			"partition": "Common",
+			"fullPath": "/Common/addresslist-bar",
+			"generation": 1,
+			"addresses": [
+			  {
+					"name": "9.8.7.6"
+				}
+			]
+		}
+	]
+}`))
+	}
+
+  ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	addressLists, err := s.Client.AddressLists(ctx)
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "GET", "/mgmt/tm/net/address-list", "")
+	assert.Equal(s.T(), 2, len(addressLists.AddressLists))
+	assert.Equal(s.T(), "addresslist-foo", addressLists.AddressLists[0].Name)
+	assert.Equal(s.T(), "addresslist-bar", addressLists.AddressLists[1].Name)
+}
+
+func (s *NetTestSuite) TestGetAddressList() {
+	s.ResponseFunc = func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{
+  "kind": "tm:net:address-list:address-liststate",
+	"selfLink": "https://localhost/mgmt/tm/net/address-list/~Common~addresslist-foo",
+	"name": "addresslist-foo",
+	"fullPath": "/Common/addresslist-foo",
+	"generation": 1,
+	"description": "An address list",
+	"addresses": [
+	  {
+      "name": "1.2.3.4"
+	  },
+		{
+			"name": "4.3.2.1"
+		}
+	]
+}`))
+	}
+
+  ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	addressList, err := s.Client.GetAddressList(ctx, "addresslist-foo")
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "GET", "/mgmt/tm/net/address-list/addresslist-foo", "")
+	assert.Equal(s.T(), "addresslist-foo", addressList.Name)
+	assert.Equal(s.T(), someAddresses, addressList.Addresses)
+}
+
+func (s *NetTestSuite) TestAddAddressList() {
+	someAddressList := AddressList{
+		Name:              "addresslist-foo",
+		Description:       "An address list",
+		Partition:         "Common",
+		Addresses:         someAddresses,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := s.Client.AddAddressList(ctx, &someAddressList)
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "POST", "/mgmt/tm/net/address-list", `{"addresses":[{"name":"1.2.3.4"}, {"name":"4.3.2.1"}], "description":"An address list", "name":"addresslist-foo", "partition":"Common"}`)
+}
+
+func (s *NetTestSuite) TestModifyAddressList() {
+	someAddressListMod := AddressList{
+		Addresses: []AddressListAddress{
+			{ Name: "6.7.8.9", },
+	  },
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := s.Client.ModifyAddressList(ctx, "addresslist-foo", &someAddressListMod)
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "PATCH", "/mgmt/tm/net/address-list/addresslist-foo", `{"addresses": [{"name": "6.7.8.9"}]}`)
+}
+
+func (s *NetTestSuite) TestDeleteAddressList() {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+
+	err := s.Client.DeleteAddressList(ctx, "addresslist-foo")
+
+	assert.Nil(s.T(), err)
+	assertRestCall(s, "DELETE", "/mgmt/tm/net/address-list/addresslist-foo", "")
+}
+


### PR DESCRIPTION
This pull request resolves https://github.com/f5devcentral/go-bigip/issues/124 and resolves https://github.com/f5devcentral/go-bigip/issues/125, by adding the following functionality:

- Get all Address Lists
- Get an Address List by name
- Create an Address List
- Modify an Address List
- Delete an Address List
- Get all Traffic Matching Criteria configurations
- Get a Traffic Matching Criteria config by name
- Create a Traffic Matching Criteria
- Modify a Traffic Matching Criteria
- Delete a Traffic Matching Criteria

Additional changes:
- Adds extra tests to net_test.go for address lists
- Adds ltm_test.go with tests for traffic matching criteria
- Adds an example for address list and traffic matching criteria usage
- Fixes two random bugs in existing tests within net_test.go